### PR TITLE
feat: 新增enableInProduction参数控制是否在生产模式开启

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,10 @@
 ﻿import * as t from '@babel/types';
 import node_path from 'path';
 
-// Define plugin options interface
 interface PluginOptions {
   enableInProduction?: boolean;
 }
 
-// type 
 export default function babelPluginAntdStyle(api: any, options: PluginOptions = {}) {
   const { enableInProduction = false } = options;
   if (process.env.NODE_ENV === 'production' && !enableInProduction) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 ﻿import * as t from '@babel/types';
 import node_path from 'path';
 
-export default function babelPluginAntdStyle() {
-  if (process.env.NODE_ENV === 'production') {
+// Define plugin options interface
+interface PluginOptions {
+  enableInProduction?: boolean;
+}
+
+// type 
+export default function babelPluginAntdStyle(api: any, options: PluginOptions = {}) {
+  const { enableInProduction = false } = options;
+  if (process.env.NODE_ENV === 'production' && !enableInProduction) {
     return {};
-  }
+  }  
   let aliasCreateStyles = 'createStyles';
   return {
     visitor: {


### PR DESCRIPTION
about https://github.com/ant-design/babel-plugin-antd-style/issues/1

## usage
```js
const obj = babel.transformFileSync(file, {
  presets: ['@babel/preset-typescript'],
  plugins: [[babelPluginAntdStyle, { enableInProduction: false }]],
});

console.log(obj.code);

```